### PR TITLE
Readme.md: Link OS-specific documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ both the Apache Mynewt and Zephyr operating systems.
 For tips on using mcumgr with your particular OS, see the appropriate file from
 the list below:
 
-* README-mynewt.md
-* README-zephyr.md
+* [Mynewt](README-mynewt.md)
+* [Zephyr](README-zephyr.md)
 
 ## Dependencies
 


### PR DESCRIPTION
Link the names of the OS-specific documentation for Mynewt and Zephyr in
the Readme files.

Signed-off-by: Johannes Hutter <johannes@proglove.de>