### PR TITLE
image erase: allow only when slot image is not backup/pending...

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -232,6 +232,11 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
     CborError err;
     int rc;
 
+    if (img_mgmt_slot_in_use(1)) {
+        /* No free slot. */
+        return MGMT_ERR_EBADSTATE;
+    }
+    
     rc = img_mgmt_impl_erase_slot();
 
     err = 0;


### PR DESCRIPTION
It was possible to erase slot 1 while it stores confirmed image
while ongoing test run - this is unwanted behavior which allow
to even brick remote device accidentally.
This patch add check for such case of test run etc.
This also aligns condition required for erase command
execution to similar as upload command requires.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>