### PR TITLE
Use a short, consistent style for prompts in Kconfig

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -16,8 +16,7 @@
 # under the License.
 
 config MCUMGR
-    bool
-    prompt "mcumgr Support"
+    bool "mcumgr Support"
     select TINYCBOR
     help
       This option enables the mcumgr management library.

--- a/cmd/fs_mgmt/Kconfig
+++ b/cmd/fs_mgmt/Kconfig
@@ -16,24 +16,21 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_FS_MGMT
-    bool
-    prompt "Enable mcumgr handlers for file management"
+    bool "Enable mcumgr handlers for file management"
     depends on FILE_SYSTEM
     help
       Enables mcumgr handlers for file management
 
 if MCUMGR_CMD_FS_MGMT
 config FS_MGMT_UL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for file uploads"
+    int "Maximum chunk size for file uploads"
     default 512
     help
       Limits the maximum chunk size for file uploads, in bytes.  A buffer of
       this size gets allocated on the stack during handling of a file upload command.
 
 config FS_MGMT_DL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for file downloads"
+    int "Maximum chunk size for file downloads"
     default 512
     help
       Limits the maximum chunk size for file downloads, in bytes.  A buffer of
@@ -41,8 +38,7 @@ config FS_MGMT_DL_CHUNK_SIZE
       command.
 
 config FS_MGMT_PATH_SIZE
-    int
-    prompt "Maximum file path length"
+    int "Maximum file path length"
     default 64
     help
       Limits the maximum path length for file operations, in bytes.  A buffer

--- a/cmd/img_mgmt/Kconfig
+++ b/cmd/img_mgmt/Kconfig
@@ -16,8 +16,7 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_IMG_MGMT
-    bool
-    prompt "Enable mcumgr handlers for image management"
+    bool "Enable mcumgr handlers for image management"
     select FLASH
     select MPU_ALLOW_FLASH_WRITE if CPU_HAS_MPU
     select IMG_MANAGER
@@ -26,8 +25,7 @@ menuconfig MCUMGR_CMD_IMG_MGMT
 
 if MCUMGR_CMD_IMG_MGMT
 config IMG_MGMT_UL_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for image uploads"
+    int "Maximum chunk size for image uploads"
     default 512
     help
       Limits the maximum chunk size for image uploads, in bytes.  A buffer of

--- a/cmd/log_mgmt/Kconfig
+++ b/cmd/log_mgmt/Kconfig
@@ -16,23 +16,20 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_LOG_MGMT
-    bool
-    prompt "Enable mcumgr handlers for log management"
+    bool "Enable mcumgr handlers for log management"
     help
       Enables mcumgr handlers for log management
 
 if MCUMGR_CMD_LOG_MGMT
 config LOG_MGMT_CHUNK_SIZE
-    int
-    prompt "Maximum chunk size for log downloads"
+    int "Maximum chunk size for log downloads"
     default 512
     help
       Limits the maximum chunk size for log downloads, in bytes.  A buffer of
       this size gets allocated on the stack during handling of the log show command.
 
 config LOG_MGMT_NAME_LEN
-    int
-    prompt "Maximum log name length"
+    int "Maximum log name length"
     default 64
     help
       Limits the maximum length of log names, in bytes.  If a log's name length
@@ -41,8 +38,7 @@ config LOG_MGMT_NAME_LEN
       management commands.
 
 config LOG_MGMT_BODY_LEN
-    int
-    prompt "Maximum log body length"
+    int "Maximum log body length"
     default 128
     help
       Limits the maximum length of log entry bodies, in bytes.  If a log

--- a/cmd/stat_mgmt/Kconfig
+++ b/cmd/stat_mgmt/Kconfig
@@ -16,16 +16,14 @@
 # Under the License.
 
 menuconfig MCUMGR_CMD_STAT_MGMT
-    bool
-    prompt "Enable mcumgr handlers for statistics management"
+    bool "Enable mcumgr handlers for statistics management"
     depends on STATS
     help
       Enables mcumgr handlers for statistics management.
 
 if MCUMGR_CMD_STAT_MGMT
 config STAT_MGMT_MAX_NAME_LEN
-    int
-    prompt "Maximum stat group name length"
+    int "Maximum stat group name length"
     default 32
     help
       Limits the maximum stat group name length in mcumgr requests, in bytes.


### PR DESCRIPTION
This synchronizes Kconfig with current Zephyr master.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>