### PR TITLE
Added initial protocol description for NMP/SMP

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -84,7 +84,10 @@ type NmpHdr struct {
 - **`Seq`**: TBD
 - **`Id`**: The command ID to send. Commands in the default `Group` are defined
   [here](https://github.com/apache/mynewt-mcumgr/blob/master/mgmt/include/mgmt/mgmt.h).
-- **`Data`**: The payload associated with the command `Id` above
+
+
+If `Len` is non-zero, the payload (referred to as **`Data`** in this document) associated
+with command `Id` immediately follows the frame header.
 
 ### Example Packets
 

--- a/protocol.md
+++ b/protocol.md
@@ -85,6 +85,7 @@ type NmpHdr struct {
 - **`Id`**: The command ID to send. Commands in the default `Group` are defined
   [here](https://github.com/apache/mynewt-mcumgr/blob/master/mgmt/include/mgmt/mgmt.h).
 
+#### `Data` Payload
 
 If `Len` is non-zero, the payload (referred to as **`Data`** in this document) associated
 with command `Id` immediately follows the frame header.

--- a/protocol.md
+++ b/protocol.md
@@ -1,10 +1,10 @@
-# SMP (Simple Management Protocol) Protocol
+# SMP (Simple Management Protocol) Protocol Notes
 
 The `mcumgr` SMP server and `mcumgr-cli` SMP client tool ([source](https://github.com/apache/mynewt-mcumgr-cli))
 use a custom protocol to send commands and responses between the server and client using a
 variety of transports (currently TTY serial or BLE).
 
-The protocol isn't documented but the following information has been inferred
+The protocol isn't fully documented but the following information has been inferred
 from the source code available on Github and using the `-l DEBUG` flag When
 executing commands.
 
@@ -221,23 +221,26 @@ When serialised this will be sent as `0x00 0x00 0x00 0x00 0x00 0x01 0x00 0x00`.
 
 ## Transports
 
-### Newtmgr Over Serial
+### Mcumgr/Newtmgr SMP Client Over Serial
 
-`newtmgr` can be used over TTY serial with the following parameters:
+`mcumgr` or `newtmgr` can be used over TTY serial with the following parameters
+to connect to a SMP server running on the target device:
 
 - Baud Rate: 115200
 - HW Flow Control: None
 
-### Newtmgr Over BLE
+### Mcumgr/Newtmgr SMP Client Over BLE
 
-`newtmgr` can be used over BLE with the following GATT service and
-characteristic UUIDs.
+`mcumgr` or `newtmgr` can be used over BLE with the following GATT service and
+characteristic UUIDs to connect to a SMP server running on the target device:
 
 - **Service UUID**: `8D53DC1D-1DB7-4CD3-868B-8A527460AA84`
 - **Characteristic UUID**: `DA2E7828-FBCE-4E01-AE9E-261174997C48`
 
-The  "newtmgr" service consists of one write no-rsp characteristic
-for newtmgr requests: a single-byte characteristic that can only
-accepts write-without-response commands.  The contents of each write
-command contains an NMP request.  NMP responses are sent back in the
-form of unsolicited notifications from the same characteristic.
+The  "SMP" (or "newtmgr") service consists of one **write no-rsp
+characteristic** for SMP requests: a single-byte characteristic that
+can only accepts write-without-response commands. The contents of
+each write command contains an SMP request.
+
+SMP responses are sent back in the form of unsolicited notifications
+from the same characteristic.

--- a/protocol.md
+++ b/protocol.md
@@ -1,8 +1,8 @@
-# Mcumgr/Newtmgr protocol
+# SMP (Simple Management Protocol) Protocol
 
-The `newtmgr` tool uses a custom protocol to send commands and responses
-between the manager and the end node using a variety of transports (currently
-TTY serial or BLE).
+The `mcumgr` SMP server and `mcumgr-cli` SMP client tool ([source](https://github.com/apache/mynewt-mcumgr-cli))
+use a custom protocol to send commands and responses between the server and client using a
+variety of transports (currently TTY serial or BLE).
 
 The protocol isn't documented but the following information has been inferred
 from the source code available on Github and using the `-l DEBUG` flag When
@@ -10,23 +10,29 @@ executing commands.
 
 ## Source Code
 
-The golang source for **newtmgr** is [available here](https://github.com/apache/mynewt-newtmgr),
+**SMP** is based on the earlier **NMP**, which is part of [Apache Mynewt](https://mynewt.apache.org/).
+
+The golang source for the original **newtmgr** is [available here](https://github.com/apache/mynewt-newtmgr),
 and can be used to provide some insight into how data is exchanged between the
 utility and the device under test.
 
-A compatible C version called **mcumgr** is also [available here](https://github.com/apache/mynewt-mcumgr).
+This repository (`mynewt-mcumgr`) implements an SMP server in **C**,
+and a new command-line SMP client called **mcumgr** was created at 
+[apache/mynewt-mcumgr](https://github.com/apache/mynewt-mcumgr).
 
-## Newtmgr/mcumgr Frame Format
+## SMP Frame Format
 
-ToDo
+TODO: High level introduction.
 
 ### Endianness
 
-Frames are normally serialized as **Big Endian** when dealing with values > 8 bits.
+Frames are normally serialized as **Big Endian** when dealing with values > 8 bits. This is
+mandatory in NMP, but the SMP implementation does add support for **Little Endian** as an
+option at the struct level, as shown below.
 
 ### Frame format
 
-Frames in newtmgr have the following format (C code taken from the mcumgr repo):
+Frames in SMP have the following format:
 
 ```
 struct mgmt_hdr {
@@ -46,7 +52,8 @@ struct mgmt_hdr {
 };
 ```
 
-The newtmgr [go source](https://github.com/apache/mynewt-newtmgr/blob/master/nmxact/nmp/nmp.go) is as follows:
+The NMP/newtmgr [go source](https://github.com/apache/mynewt-newtmgr/blob/master/nmxact/nmp/nmp.go) is as follows,
+without the option to select endianness:
 
 ```
 type NmpHdr struct {
@@ -85,7 +92,7 @@ The following example commands show how the different fields work:
 
 #### Simple Read Request: `taskstats`
 
-The following example corresponds to the `taskstats` command in newtmgr, and
+The following example corresponds to the `taskstats` command ([source](https://github.com/apache/mynewt-mcumgr/blob/master/cmd/os_mgmt/include/os_mgmt/os_mgmt.h)), and
 can be seen by running `newtmgr -l DEBUG -c serial taskstats`:
 
 ```
@@ -94,7 +101,7 @@ Flags: 0
 Len:   0  # No payload present
 Group: 0  # 0x00 = NMGR_GROUP_ID_DEFAULT
 Seq:   0
-Id:    2  # 0x02 in group 0x00 = NMGR_ID_TASKSTATS
+Id:    2  # 0x02 in group 0x00 = OS_MGMT_ID_TASKSTAT
 Data:  [] # No payload (len = 0 above)
 ```
 


### PR DESCRIPTION
This PR is based on some documentation from [Adafruit_Mynewt](https://github.com/adafruit/Adafruit_Mynewt/tree/master/docs), and attempts to describe some of the basics of the nmp protocol used by both newtmgr and mcumgr.

The original documentation is based on an early release of the protocol in the context of Apache Mynewt, but an attempt has been made to bring the links and basic details up to date with the golang based `newtmgr` and the C based `mcumgr` projects.

Further extensions to this document are of course welcome and necessary to help people implement nmp in their mobile, desktop or other applications.