### PR TITLE
Zephyr/align to dinamic flash map

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -218,7 +218,7 @@ zephyr_img_mgmt_init(struct device *dev)
 {
     ARG_UNUSED(dev);
 
-    zephyr_img_mgmt_flash_dev = device_get_binding(FLASH_DEV_NAME);
+    zephyr_img_mgmt_flash_dev = device_get_binding(DT_FLASH_DEV_NAME);
     if (zephyr_img_mgmt_flash_dev == NULL) {
         return -ENODEV;
     }


### PR DESCRIPTION
Changes in flash_map API makes flash_area structure proper
interface for point the image area instead of direct flash-bank-offsets.

This patch align code to changed APIa and allows to support operation
on the partition in any flash device.

This patch is part of zephyrproject-rtos/zephyr#8837
Merge after above PR.

Signed-off-by: Findlay Feng <i@fengch.me>
Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>