### PR TITLE
smp-console.md: clarify 128-byte max frame size

### DIFF
--- a/transport/smp-console.md
+++ b/transport/smp-console.md
@@ -6,7 +6,8 @@ transmitted over text consoles.
 ## Overview
 
 Mcumgr packets sent over serial are fragmented into frames of 128 bytes or
-fewer.
+fewer.  This 128-byte maximum applies to the entire frame, including header,
+CRC, and terminating newline.
 
 The initial frame in a packet has the following format:
 


### PR DESCRIPTION
The 128 maximum size applies to the entire frame including header, CRC, and terminating newline.