### PR TITLE
log_mgmt: Seperate out log_mgmt errors

### DIFF
--- a/cmd/log_mgmt/include/log_mgmt/log_mgmt.h
+++ b/cmd/log_mgmt/include/log_mgmt/log_mgmt.h
@@ -27,6 +27,22 @@ extern "C" {
 #include "log_mgmt_config.h"
 
 /**
+ * LOG MGMT specific error codes, 0 -> 6, 8 are same as mcumgr,
+ * 7 and 9 are different for backwards compatibility with newtmgr.
+ */
+#define LOG_MGMT_ERR_EOK        (0)                                  
+#define LOG_MGMT_ERR_EUNKNOWN   (1)                                  
+#define LOG_MGMT_ERR_ENOMEM     (2)                                  
+#define LOG_MGMT_ERR_EINVAL     (3)                                  
+#define LOG_MGMT_ERR_ETIMEOUT   (4)
+#define LOG_MGMT_ERR_ENOENT     (5)
+#define LOG_MGMT_ERR_EBADSTATE  (6)     /* Current state disallows command. */
+#define LOG_MGMT_ERR_ECORRUPT   (7)
+#define LOG_MGMT_ERR_ENOTSUP    (8)
+#define LOG_MGMT_ERR_EMSGSIZE   (9)
+#define LOG_MGMT_ERR_EPERUSER   (256)
+
+/**
  * Command IDs for log management group.
  */
 #define LOG_MGMT_ID_SHOW        0

--- a/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
+++ b/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
@@ -58,13 +58,13 @@ log_mgmt_impl_set_watermark(struct log_mgmt_log *log, int index)
     for (i = 0; i <= index; i++) {
         tmplog = log_list_get_next(tmplog);
         if (tmplog == NULL) {
-            return MGMT_ERR_ENOENT;
+            return LOG_MGMT_ERR_ENOENT;
         }
     }
 
     return log_set_watermark(tmplog, index);
 #else
-    return MGMT_ERR_ENOTSUP;
+    return LOG_MGMT_ERR_ENOTSUP;
 #endif
 }
 
@@ -78,7 +78,7 @@ log_mgmt_impl_get_log(int idx, struct log_mgmt_log *out_log)
     for (i = 0; i <= idx; i++) {
         log = log_list_get_next(log);
         if (log == NULL) {
-            return MGMT_ERR_ENOENT;
+            return LOG_MGMT_ERR_ENOENT;
         }
     }
 
@@ -97,7 +97,7 @@ log_mgmt_impl_get_module(int idx, const char **out_module_name)
 
     name = LOG_MODULE_STR(idx);
     if (name == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     } else {
         *out_module_name = name;
         return 0;
@@ -111,7 +111,7 @@ log_mgmt_impl_get_level(int idx, const char **out_level_name)
 
     name = LOG_LEVEL_STR(idx);
     if (name == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     } else {
         *out_level_name = name;
         return 0;
@@ -189,7 +189,7 @@ mynewt_log_mgmt_walk_cb(struct log *log, struct log_offset *log_offset,
         rc = log_read_body(log, dptr, mynewt_log_mgmt_walk_arg->chunk, offset,
                            read_len);
         if (rc < 0) {
-            return MGMT_ERR_EUNKNOWN;
+            return LOG_MGMT_ERR_EUNKNOWN;
         }
         rc = mynewt_log_mgmt_walk_arg->cb(&entry, mynewt_log_mgmt_walk_arg->arg);
         if (rc) {
@@ -216,7 +216,7 @@ log_mgmt_impl_foreach_entry(const char *log_name,
 
     log = mynewt_log_mgmt_find_log(log_name);
     if (log == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     }
 
     if (strcmp(log->l_name, log_name) == 0) {
@@ -228,7 +228,7 @@ log_mgmt_impl_foreach_entry(const char *log_name,
         return log_walk_body(log, mynewt_log_mgmt_walk_cb, &offset);
     }
 
-    return MGMT_ERR_ENOENT;
+    return LOG_MGMT_ERR_ENOENT;
 }
 
 int
@@ -239,12 +239,12 @@ log_mgmt_impl_clear(const char *log_name)
 
     log = mynewt_log_mgmt_find_log(log_name);
     if (log == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     }
 
     rc = log_flush(log);
     if (rc != 0) {
-        return MGMT_ERR_EUNKNOWN;
+        return LOG_MGMT_ERR_EUNKNOWN;
     }
 
     return 0;

--- a/cmd/log_mgmt/port/zephyr/src/zephyr_log_mgmt.c
+++ b/cmd/log_mgmt/port/zephyr/src/zephyr_log_mgmt.c
@@ -40,7 +40,7 @@ log_mgmt_impl_get_log(int idx, struct log_mgmt_log *out_log)
     for (i = 0; i <= idx; i++) {
         mdlog = mdlog_get_next(mdlog);
         if (mdlog == NULL) {
-            return MGMT_ERR_ENOENT;
+            return LOG_MGMT_ERR_ENOENT;
         }
     }
 
@@ -56,7 +56,7 @@ log_mgmt_impl_get_module(int idx, const char **out_module_name)
 
     name = mdlog_module_name(idx);
     if (name == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     } else {
         *out_module_name = name;
         return 0;
@@ -70,7 +70,7 @@ log_mgmt_impl_get_level(int idx, const char **out_level_name)
 
     name = mdlog_level_name(idx);
     if (name == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     } else {
         *out_level_name = name;
         return 0;
@@ -98,7 +98,7 @@ zephyr_log_mgmt_walk_cb(struct mdlog *log, struct mdlog_offset *log_offset,
 
     rc = mdlog_read(log, desciptor, &ueh, 0, sizeof ueh);
     if (rc != sizeof ueh) {
-        return MGMT_ERR_EUNKNOWN;
+        return LOG_MGMT_ERR_EUNKNOWN;
     }
 
     /* If specified timestamp is nonzero, it is the primary criterion, and the
@@ -125,7 +125,7 @@ zephyr_log_mgmt_walk_cb(struct mdlog *log, struct mdlog_offset *log_offset,
     rc = mdlog_read(log, desciptor, zephyr_log_mgmt_walk_arg->body, sizeof ueh,
                     read_len);
     if (rc < 0) {
-        return MGMT_ERR_EUNKNOWN;
+        return LOG_MGMT_ERR_EUNKNOWN;
     }
 
     entry.ts = ueh.ue_ts;
@@ -154,7 +154,7 @@ log_mgmt_impl_foreach_entry(const char *log_name,
 
     mdlog = mdlog_find(log_name);
     if (mdlog == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     }
 
     if (strcmp(mdlog->l_name, log_name) == 0) {
@@ -166,7 +166,7 @@ log_mgmt_impl_foreach_entry(const char *log_name,
         return mdlog_walk(mdlog, zephyr_log_mgmt_walk_cb, &offset);
     }
 
-    return MGMT_ERR_ENOENT;
+    return LOG_MGMT_ERR_ENOENT;
 }
 
 int
@@ -177,12 +177,12 @@ log_mgmt_impl_clear(const char *log_name)
 
     mdlog = mdlog_find(log_name);
     if (mdlog == NULL) {
-        return MGMT_ERR_ENOENT;
+        return LOG_MGMT_ERR_ENOENT;
     }
 
     rc = mdlog_flush(mdlog);
     if (rc != 0) {
-        return MGMT_ERR_EUNKNOWN;
+        return LOG_MGMT_ERR_EUNKNOWN;
     }
 
     return 0;


### PR DESCRIPTION
- log_mgmt errors are separated out now to support backwards compatible
  behavior with newtmgr in mynewt-core