### PR TITLE
Add `version.yml` file.

### DIFF
--- a/version.yml
+++ b/version.yml
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Newt uses this file to determine the version of a checked out repo.
+# This should always be 0.0.0 in the master branch.
+repo.version: 0.0.0


### PR DESCRIPTION
Newt requires this file to determine which version a given commit in a repo corresponds to.

Without this file, `newt upgrade` reports the warnings similar to these:
```
WARNING: Could not detect version of installed repo "apache-mynewt-mcumgr"; assuming 0.0.0/17a64fb7609c2fc71d7acf55889bad99d27c0c36
WARNING: apache-mynewt-mcumgr:17a64fb7609c2fc71d7acf55889bad99d27c0c36 does not contain a `version.yml` file.
WARNING: Could not detect version of requested repo apache-mynewt-mcumgr:17a64fb7609c2fc71d7acf55889bad99d27c0c36; assuming 0.0.0
```
In master, the version should always be 0.0.0.