### PR TITLE
log_mgmt:watermark should be set at last log entry

### DIFF
--- a/cmd/log_mgmt/include/log_mgmt/log_mgmt_impl.h
+++ b/cmd/log_mgmt/include/log_mgmt/log_mgmt_impl.h
@@ -122,7 +122,7 @@ int log_mgmt_impl_clear(const char *log_name);
  * @return                      0 on success, non-zero on failure
  */
 int
-log_mgmt_impl_set_watermark(struct log_mgmt_log *log, int index);
+log_mgmt_impl_set_watermark(const struct log_mgmt_log *log, int index);
 
 #ifdef __cplusplus
 }

--- a/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
+++ b/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
@@ -75,7 +75,7 @@ log_mgmt_mynewt_err_map(int mynewt_os_err)
 }
 
 int
-log_mgmt_impl_set_watermark(struct log_mgmt_log *log, int index)
+log_mgmt_impl_set_watermark(const struct log_mgmt_log *log, int index)
 {
 #if MYNEWT_VAL(LOG_STORAGE_WATERMARK)
     struct log *tmplog;

--- a/cmd/log_mgmt/src/log_mgmt.c
+++ b/cmd/log_mgmt/src/log_mgmt.c
@@ -315,7 +315,7 @@ log_encode_entries(const struct log_mgmt_log *log, CborEncoder *enc,
 
 #if LOG_MGMT_READ_WATERMARK_UPDATE
     if (!rc) {
-        rc = log_mgmt_impl_set_watermark(log, ctxt.last_enc_index);
+        log_mgmt_impl_set_watermark(log, ctxt.last_enc_index);
     }
 #endif
 err:

--- a/cmd/log_mgmt/src/stubs.c
+++ b/cmd/log_mgmt/src/stubs.c
@@ -65,7 +65,7 @@ log_mgmt_impl_clear(const char *log_name)
 }
 
 int __attribute__((weak))
-log_mgmt_impl_set_watermark(struct log_mgmt_log *log, int index)
+log_mgmt_impl_set_watermark(const struct log_mgmt_log *log, int index)
 {
     return MGMT_ERR_ENOTSUP;
 }


### PR DESCRIPTION
- Earlier watermark was set for the first entry, it should be the last
one, this watermark can get persisted hence, we need to only remember or
persist the watermark once at the end of the response.
This fixes https://github.com/apache/mynewt-mcumgr/issues/44