### PR TITLE
Handle "UNKNOWN" on log_mgmt_impl_get_level

### DIFF
--- a/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
+++ b/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
@@ -132,8 +132,12 @@ log_mgmt_impl_get_level(int idx, const char **out_level_name)
 {
     const char *name;
 
+    if (idx >= LOG_LEVEL_MAX) {
+        return LOG_MGMT_ERR_ENOENT;
+    }
+
     name = LOG_LEVEL_STR(idx);
-    if (name == NULL) {
+    if (!strcmp(name, "UNKNOWN")) {
         return LOG_MGMT_ERR_ENOENT;
     } else {
         *out_level_name = name;


### PR DESCRIPTION
Currently mcumgr log level_list command isn't working because it expects LOG_LEVEL_IDX to return NULL instead of the string "UNKNOWN" when a non valid level index is provided.