### PR TITLE
log_mgmt: Set watermark on filling up log rsp

### DIFF
--- a/cmd/log_mgmt/src/log_mgmt.c
+++ b/cmd/log_mgmt/src/log_mgmt.c
@@ -313,12 +313,12 @@ log_encode_entries(const struct log_mgmt_log *log, CborEncoder *enc,
         return LOG_MGMT_ERR_ENOMEM;
     }
 
+err:
 #if LOG_MGMT_READ_WATERMARK_UPDATE
-    if (!rc) {
+    if (!rc || rc == LOG_MGMT_ERR_EUNKNOWN) {
         log_mgmt_impl_set_watermark(log, ctxt.last_enc_index);
     }
 #endif
-err:
     return rc;
 }
 


### PR DESCRIPTION
- After filling up log responses, set the watermark as well. We have to
honor LOG_MGMT_ERR_UNKNOWN.