### PR TITLE
img_mgmt: Add img_mgmt_dfu_confirmed() callback in img_mgmt_state.c

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -176,6 +176,7 @@ img_mgmt_state_confirm(void)
         rc = MGMT_ERR_EUNKNOWN;
     }
 
+     img_mgmt_dfu_confirmed();
 err:
     return img_mgmt_impl_log_confirm(rc, NULL);
 }


### PR DESCRIPTION
- This was missed out during the transition from newtmgr to
  mcumgr