### PR TITLE
img_mgmt: TLVs were not getting parsed correctly

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/image.h
+++ b/cmd/img_mgmt/include/img_mgmt/image.h
@@ -28,6 +28,7 @@ extern "C" {
 
 #define IMAGE_MAGIC                 0x96f3b83d
 #define IMAGE_TLV_INFO_MAGIC        0x6907
+#define IMAGE_TLV_PROT_INFO_MAGIC   0x6908
 
 #define IMAGE_HEADER_SIZE           32
 


### PR DESCRIPTION
- Protected TLVs should get parsed first and then the regular TLVs
  should get parsed