### PR TITLE
Set CBORATTR_MAX_SIZE default when no Kconfig counterpart is defined.

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -23,7 +23,11 @@
 
 #ifdef __ZEPHYR__
 #include <zephyr.h>
+#ifdef CONFIG_MGMT_CBORATTR_MAX_SIZE
 #define CBORATTR_MAX_SIZE CONFIG_MGMT_CBORATTR_MAX_SIZE
+#else
+#define CBORATTR_MAX_SIZE 512
+#endif
 #endif
 
 #ifdef MYNEWT


### PR DESCRIPTION
This is a temporary solution so Zephyr may compile while zephyr doesn't feature the MGMT_CBORATTR_MAX_SIZE Kconfig val. 