### PR TITLE
cmd: img_mgmt: fix driver include path

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -23,7 +23,7 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <assert.h>
-#include <flash.h>
+#include <drivers/flash.h>
 #include <storage/flash_map.h>
 #include <zephyr.h>
 #include <soc.h>


### PR DESCRIPTION
Zephyr will soon no longer add the drivers subdirectory of the include
hierarchy to the search path, so references to driver headers must
include the drivers/ prefix.

Signed-off-by: Peter A. Bigot <peter.bigot@nordicsemi.no>