### PR TITLE
smp_svr: Change the stack size to 564

### DIFF
--- a/samples/smp_svr/mynewt/syscfg.yml
+++ b/samples/smp_svr/mynewt/syscfg.yml
@@ -36,7 +36,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 468
+    OS_MAIN_STACK_SIZE: 564
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
Based on the investigation we did, it seems the stack was overflowing by 92 bytes, so I am going to increase it by 96 bytes from the previous value which was 468.

