### PR TITLE
mynewt_smp_svr: Stack is 8 byte aligned, 564 -> 568

### DIFF
--- a/samples/smp_svr/mynewt/syscfg.yml
+++ b/samples/smp_svr/mynewt/syscfg.yml
@@ -36,7 +36,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 564
+    OS_MAIN_STACK_SIZE: 568
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
- On the mynewt side, OS main stack size should be set to 568 since taskstat
  shows the 8 byte aligned value for the stack size