### PR TITLE
Add Zephyr `smp_svr` build testing to Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+language: python
+
+dist: bionic
+
+git:
+  depth: false
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          packages:
+            - gperf
+
+install:
+  - ./ci/zephyr_install.sh
+
+script:
+  - ./ci/zephyr_run.sh
+
+cache:
+  directories:
+  - $HOME/zephyr_sdk_download

--- a/ci/zephyr_install.sh
+++ b/ci/zephyr_install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash -x
+
+export ZEPHYR_BASE="${HOME}/zephyr"
+
+ZEPHYR_SDK_RELEASE="0.11.0"
+ZEPHYR_SDK="zephyr-sdk-${ZEPHYR_SDK_RELEASE}-setup.run"
+ZEPHYR_SDK_URL="https://github.com/zephyrproject-rtos/sdk-ng/releases/download/v${ZEPHYR_SDK_RELEASE}/${ZEPHYR_SDK}"
+
+CMAKE_RELEASE="3.16.3"
+CMAKE="cmake-${CMAKE_RELEASE}-Linux-x86_64.sh"
+CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v${CMAKE_RELEASE}/${CMAKE}"
+
+export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_SDK_INSTALL_DIR="${HOME}/zephyr-sdk"
+
+repos=(
+    "https://github.com/zephyrproject-rtos/zephyr"
+    "https://github.com/zephyrproject-rtos/hal_nordic"
+    "https://github.com/zephyrproject-rtos/littlefs"
+    "https://github.com/zephyrproject-rtos/tinycbor"
+)
+
+for repo in "${repos[@]}"; do
+    git clone --depth=1 ${repo} "${HOME}/$(basename ${repo})"
+    [[ $rc -ne 0 ]] && exit 1
+done
+
+source ${ZEPHYR_BASE}/zephyr-env.sh
+
+download_dir=$HOME/download
+mkdir -p ${download_dir}
+
+wget -O ${download_dir}/${CMAKE} -c ${CMAKE_URL}
+[[ $? -ne 0 ]] && exit 1
+
+chmod +x ${download_dir}/${CMAKE}
+${download_dir}/${CMAKE} --skip-license --prefix="${HOME}/.local" --exclude-subdir
+[[ $? -ne 0 ]] && exit 1
+
+wget -O ${download_dir}/${ZEPHYR_SDK} -c ${ZEPHYR_SDK_URL}
+[[ $? -ne 0 ]] && exit 1
+
+chmod +x ${download_dir}/${ZEPHYR_SDK}
+${download_dir}/${ZEPHYR_SDK} --quiet --noprogress -- -d "${ZEPHYR_SDK_INSTALL_DIR}" -y
+[[ $? -ne 0 ]] && exit 1
+
+pip install PyYAML pyelftools pykwalify

--- a/ci/zephyr_run.sh
+++ b/ci/zephyr_run.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -x
+
+export ZEPHYR_BASE=$HOME/zephyr
+
+export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_SDK_INSTALL_DIR=$HOME/zephyr-sdk
+
+# This repo - cloned by travis
+MCUMGR="${HOME}/build/apache/mynewt-mcumgr"
+
+# Cloned by zephyr_install.sh
+NRFX="${HOME}/hal_nordic"
+LITTLEFS="${HOME}/littlefs"
+TINYCBOR="${HOME}/tinycbor"
+
+ZEPHYR_MODULES="${NRFX};${MCUMGR};${LITTLEFS};${TINYCBOR}"
+BUILD_DIR="${HOME}/build"
+
+apps=(
+    "${ZEPHYR_BASE}/samples/subsys/mgmt/mcumgr/smp_svr"
+    "${MCUMGR}/samples/smp_svr/zephyr"
+)
+
+for app in "${apps[@]}"; do
+    mkdir -p "${BUILD_DIR}" && pushd "${BUILD_DIR}"
+
+    ${HOME}/.local/bin/cmake -DBOARD=nrf52840_pca10056 -DZEPHYR_MODULES="${ZEPHYR_MODULES}" \
+        "${app}"
+    [[ $? -ne 0 ]] && exit 1
+
+    make -j4
+    [[ $? -ne 0 ]] && exit 1
+
+    popd && rm -rf "${BUILD_DIR}"
+done
+
+exit 0


### PR DESCRIPTION
This builds `smp_svr` directly from the Zephyr tree; the purpose is to assure that the provided sample is still in a good build state when the mcumgr code changes.