### PR TITLE
ext: lib: mgmt: Enabling Zephyr/mynewt-core version of tinycbor

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -400,11 +400,7 @@ cbor_read_flat_attrs(const uint8_t *data, int len,
     CborError err;
 
     cbor_buf_reader_init(&reader, data, len);
-#ifdef __ZEPHYR__
-    err = cbor_parser_cust_reader_init(&reader.r, 0, &parser, &value);
-#else
     err = cbor_parser_init(&reader.r, 0, &parser, &value);
-#endif
     if (err != CborNoError) {
         return -1;
     }

--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -157,21 +157,12 @@ mgmt_ctxt_init(struct mgmt_ctxt *ctxt, struct mgmt_streamer *streamer)
 {
     int rc;
 
-#ifdef __ZEPHYR__
-    rc = cbor_parser_cust_reader_init(streamer->reader, 0, &ctxt->parser,
-                                      &ctxt->it);
-#else
     rc = cbor_parser_init(streamer->reader, 0, &ctxt->parser, &ctxt->it);
-#endif
     if (rc != CborNoError) {
         return mgmt_err_from_cbor(rc);
     }
 
-#ifdef __ZEPHYR__
-    cbor_encoder_cust_writer_init(&ctxt->encoder, streamer->writer, 0);
-#else
     cbor_encoder_init(&ctxt->encoder, streamer->writer, 0);
-#endif
 
     return 0;
 }


### PR DESCRIPTION
Changes needed due to overwrite of Zephyr fork of Tinycbor with
mynewt-core version.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>