### PR TITLE
zephyr: board nrf51_pca10028 renamed to nrf51dk_nrf51422

### DIFF
--- a/samples/smp_svr/zephyr/sample.yaml
+++ b/samples/smp_svr/zephyr/sample.yaml
@@ -7,6 +7,6 @@ common:
 tests:
   sample.mcumg.smp_svr.nrf51:
     extra_args: CONF_FILE="prj_tiny.conf"
-    platform_whitelist: nrf51_pca10028
+    platform_whitelist: nrf51dk_nrf51422
   sample.mcumg.smp_svr.nrf52:
     platform_whitelist: nrf52_pca10040 nrf52840_pca10056


### PR DESCRIPTION
Name of the board is changing in the zephyr-rtos:
zephyrproject-rtos/zephyr#23447

This patch aligns the board name used which is required for suppression
of build warnings.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>