### PR TITLE
zephyr: TinyCBOR has been removed from interface libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,6 @@ zephyr_library_link_libraries(MCUMGR)
 
 target_link_libraries(MCUMGR INTERFACE
   zephyr_interface
-  TINYCBOR
   )
 
 endif()


### PR DESCRIPTION
DEPENDS ON:
zephyrproject-rtos/tinycbor#13

It is no longer needed to add TINYCBOR to list of interface libraries.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>