### PR TITLE
omp_svr: Change the stack size to 568

### DIFF
--- a/samples/omp_svr/mynewt/syscfg.yml
+++ b/samples/omp_svr/mynewt/syscfg.yml
@@ -35,7 +35,7 @@ syscfg.vals:
     CONFIG_MGMT: 1
 
     # OS main/default task
-    OS_MAIN_STACK_SIZE: 468
+    OS_MAIN_STACK_SIZE: 568
 
     # Lots of smaller mbufs are required for smp using typical BLE ATT MTU
     # values.


### PR DESCRIPTION
omp_svr had the same problem as described on https://github.com/apache/mynewt-mcumgr/pull/59 for smp_svr. This PR increases the stack size to 568 since the stack was overflowing by 90 bytes in this case.