### PR TITLE
zephyr: Convert k_timer calls to new API

### DIFF
--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -91,6 +91,6 @@ zephyr_os_mgmt_reset_cb(struct k_timer *timer)
 int
 os_mgmt_impl_reset(unsigned int delay_ms)
 {
-    k_timer_start(&zephyr_os_mgmt_reset_timer, K_MSEC(delay_ms), 0);
+    k_timer_start(&zephyr_os_mgmt_reset_timer, K_MSEC(delay_ms), K_NO_WAIT);
     return 0;
 }


### PR DESCRIPTION
The new API does not accept integer types for timeouts, instead it uses
k_timeout_t structure.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>