### PR TITLE
cmd/img_mgmt/port/zephyr: fix to img_mgmt_impl_erase_image_data()

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -95,16 +95,16 @@ zephyr_img_mgmt_flash_area_id(int slot)
 
     switch (slot) {
     case 0:
-        fa_id = DT_FLASH_AREA_IMAGE_0_ID;
+        fa_id = FLASH_AREA_ID(image_0);
         break;
 
     case 1:
-        fa_id = DT_FLASH_AREA_IMAGE_1_ID;
+        fa_id = FLASH_AREA_ID(image_1);
         break;
 
     default:
         assert(0);
-        fa_id = DT_FLASH_AREA_IMAGE_1_ID;
+        fa_id = FLASH_AREA_ID(image_1);
         break;
     }
 
@@ -189,14 +189,14 @@ img_mgmt_impl_erase_slot(void)
     bool empty;
     int rc;
 
-    rc = zephyr_img_mgmt_flash_check_empty(DT_FLASH_AREA_IMAGE_1_ID,
+    rc = zephyr_img_mgmt_flash_check_empty(FLASH_AREA_ID(image_1),
                                            &empty);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }
 
     if (!empty) {
-        rc = boot_erase_img_bank(DT_FLASH_AREA_IMAGE_1_ID);
+        rc = boot_erase_img_bank(FLASH_AREA_ID(image_1));
         if (rc != 0) {
             return MGMT_ERR_EUNKNOWN;
         }
@@ -318,7 +318,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     const struct flash_area *fa;
     int rc;
 
-    rc = flash_area_open(DT_FLASH_AREA_IMAGE_1_ID, &fa);
+    rc = flash_area_open(FLASH_AREA_ID(image_1), &fa);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }

--- a/samples/smp_svr/zephyr/src/main.c
+++ b/samples/smp_svr/zephyr/src/main.c
@@ -65,7 +65,7 @@ FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(cstorage);
 static struct fs_mount_t littlefs_mnt = {
 	.type = FS_LITTLEFS,
 	.fs_data = &cstorage,
-	.storage_dev = (void *)DT_FLASH_AREA_STORAGE_ID,
+	.storage_dev = (void *)FLASH_AREA_ID(storage),
 	.mnt_point = "/lfs"
 };
 #endif


### PR DESCRIPTION
It was possible that the function tried to eras non erase-block-size
aligned number of bytes witch might have cause failure.
Additionally the image trailer area might have been not erased at all.

Reworked implementation so:
 - the erase request is corrected to erase proper amount of memory
 - erase of image trailer is ensured.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>

PR initiated per request from @nvlsianpu (https://github.com/zephyrproject-rtos/mcumgr/pull/22)