### PR TITLE
cmd/img_mgmt/port/zephyr: suppress warnings with logging enabled

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -347,13 +347,13 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
     rc = flash_area_erase(fa, 0, erase_size);
 
     if (rc != 0) {
-        LOG_ERR("image slot erase of 0x%x bytes failed (err %d)", erase_size,
+        LOG_ERR("image slot erase of 0x%zx bytes failed (err %d)", erase_size,
                 rc);
         rc = MGMT_ERR_EUNKNOWN;
         goto end_fa;
     }
 
-    LOG_INF("Erased 0x%x bytes of image slot", erase_size);
+    LOG_INF("Erased 0x%zx bytes of image slot", erase_size);
 
     /* erase the image trailer area if it was not erased */
     off = BOOT_TRAILER_IMG_STATUS_OFFS(fa);
@@ -365,13 +365,13 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
 
         rc = flash_area_erase(fa, off, erase_size);
         if (rc != 0) {
-            LOG_ERR("image slot trailer erase of 0x%x bytes failed (err %d)",
+            LOG_ERR("image slot trailer erase of 0x%zx bytes failed (err %d)",
                     erase_size, rc);
             rc = MGMT_ERR_EUNKNOWN;
             goto end_fa;
         }
 
-        LOG_INF("Erased 0x%x bytes of image slot trailer", erase_size);
+        LOG_INF("Erased 0x%zx bytes of image slot trailer", erase_size);
     }
 
     rc = 0;


### PR DESCRIPTION
Following warning message appears when building Zephyr for qemu_x86 platform:

  /zephyr/include/logging/log_core.h:238:10: warning: format '%x' \
    expects argument of type 'unsigned int', but argument 3 has type \
    'long unsigned int' [-Wformat=]

Suppress that by casting to unsigned int.

Following warning messages appear when building Zephyr for
native_posix_64 platform:

  /zephyr/include/logging/log_core.h:238:10: warning: format ‘%x’ \
    expects argument of type ‘unsigned int’, but argument 2 has type \
    ‘size_t’ {aka ‘long unsigned int’} [-Wformat=]

Suppress that by using %zx instead of %x.

Signed-off-by: Marcin Niestroj <m.niestroj@grinn-global.com>