### PR TITLE
zephyr: Add file open flags to fs_open calls

### DIFF
--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -49,9 +49,9 @@ fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
     ssize_t bytes_read;
     int rc;
 
-    rc = fs_open(&file, path);
+    rc = fs_open(&file, path, FS_O_READ);
     if (rc != 0) {
-        return MGMT_ERR_EUNKNOWN;
+        return MGMT_ERR_ENOENT;
     }
 
     rc = fs_seek(&file, offset, FS_SEEK_SET);
@@ -123,7 +123,7 @@ fs_mgmt_impl_write(const char *path, size_t offset, const void *data,
         }
     }
 
-    rc = fs_open(&file, path);
+    rc = fs_open(&file, path, FS_O_CREATE | FS_O_WRITE);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }


### PR DESCRIPTION
With addition of open flags to fs_open calls, all invocations that do
not provide them require change.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>