### PR TITLE
mcuboot: fix for interrupted slot-1 erase

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -156,9 +156,11 @@ int img_mgmt_ver_str(const struct image_version *ver, char *dst);
  *
  * @param slot Slot to check if its in use
  *
+ * @param in_use Destination boolean for in use state
+ *
  * @return 0 on success, non-zero on failure
  */
-int img_mgmt_slot_in_use(int slot);
+int img_mgmt_slot_in_use(int slot, bool *in_use);
 
 /**
  * @brief Check if the DFU status is pending

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -33,6 +33,7 @@ img_mgmt_find_best_area_id(void)
     int best = -1;
     int i;
     int rc;
+    bool in_use = true;
 
     for (i = 0; i < 2; i++) {
         rc = img_mgmt_read_info(i, &ver, NULL, NULL);
@@ -41,7 +42,12 @@ img_mgmt_find_best_area_id(void)
         }
         if (rc == 0) {
             /* Image in slot is ok. */
-            if (img_mgmt_slot_in_use(i)) {
+            rc = img_mgmt_slot_in_use(i, &in_use);
+            if (rc != 0) {
+                /* Cannot determine if slot is in use */
+                continue;
+            }
+            if (in_use) {
                 /* Slot is in use; can't use this. */
                 continue;
             } else {

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -118,6 +118,7 @@ img_mgmt_find_best_area_id(void)
     int best = -1;
     int i;
     int rc;
+    bool in_use = true;
 
     for (i = 0; i < 2; i++) {
         rc = img_mgmt_read_info(i, &ver, NULL, NULL);
@@ -126,7 +127,12 @@ img_mgmt_find_best_area_id(void)
         }
         if (rc == 0) {
             /* Image in slot is ok. */
-            if (img_mgmt_slot_in_use(i)) {
+            rc = img_mgmt_slot_in_use(i, &in_use);
+            if (rc != 0) {
+                /* Cannot determine if slot is in use */
+                continue;
+            }
+            if (in_use) {
                 /* Slot is in use; can't use this. */
                 continue;
             } else {

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -287,8 +287,13 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 {
     CborError err;
     int rc;
+    bool in_use;
 
-    if (img_mgmt_slot_in_use(1)) {
+    rc = img_mgmt_slot_in_use(1, &in_use);
+    if (rc != 0) {
+        return rc;
+    }
+    if (in_use) {
         /* No free slot. */
         return MGMT_ERR_EBADSTATE;
     }


### PR DESCRIPTION
This is a fix for devices in the field using mcuboot versions v1.6.0 or less.

If a firmware update is attempted with a corrupt image and a power outage or
reset occurs while the bootloader* is erasing the corrupt image then the
secondary (slot-1) can be left in a state where the bootloader has not
properly released slot-1 and a DFU transfer can no longer happen. Attempts
to upload will transfer 0 bytes as the trailer at the end of the slot remains
present and indicates the slot is 'in use' blocking the slot erase operation
that occurs on reception of the 1st image block or when an image erase command
is issued.

This commit fixes this issue by adding an additional requirement to determine
if a slot is 'in use': the image header magic value located at the beginning
of the slot must also present. If this additional requirement is not also met
then the slot is considered not in use.

* The issue was originally discovered with Zephyr v1.14 LTS and mcuboot release
v1.3.1 and a fix for mcuboot has been applied here:
https://github.com/JuulLabs-OSS/mcuboot/pull/765
mcuboot commit: 42335be22bc8fb576845f41e6174f1921fcff5d9

A fix for mcumgr library in Zephyr v1.14 LTS is in progress here:
https://github.com/zephyrproject-rtos/zephyr/pull/26738

Signed-off-by: Nick Ward <nick.ward@setec.com.au>