### PR TITLE
Fix image erase command for partial slot-1 erase

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -285,12 +285,22 @@ img_mgmt_error_rsp(struct mgmt_ctxt *ctxt, int rc, const char *rsn)
 static int
 img_mgmt_erase(struct mgmt_ctxt *ctxt)
 {
+    struct image_version ver;
     CborError err;
     int rc;
 
-    if (img_mgmt_slot_in_use(1)) {
-        /* No free slot. */
-        return MGMT_ERR_EBADSTATE;
+    /*
+     * First check if image info is valid.
+     * This check is done incase the flash area has a corrupted image.
+     */
+    rc = img_mgmt_read_info(1, &ver, NULL, NULL);
+
+    if (rc == 0) {
+        /* Image info is valid. */
+        if (img_mgmt_slot_in_use(1)) {
+            /* No free slot. */
+            return MGMT_ERR_EBADSTATE;
+        }
     }
     
     rc = img_mgmt_impl_erase_slot();


### PR DESCRIPTION
This is a fix for devices in the field using mcuboot versions v1.6.0 or less.

If a firmware update is attempted with a corrupt image and a power outage or
reset occurs while the bootloader* is erasing the corrupt image then the
secondary (slot-1) can be left in a state where the bootloader has not
properly released slot-1 and a DFU transfer can no longer happen. Attempts
to execute the image erase command will fail with 6 (MGMT_ERR_EBADSTATE).

This commit fixes this issue by adding an additional requirement to determine
if a slot is 'in use': the image must also be valid. If this additional
requirement is not also met then the slot is considered not in use.

* The issue was originally discovered with Zephyr v1.14 LTS and mcuboot release
v3.1 and a fix for mcuboot has been applied here:
https://github.com/JuulLabs-OSS/mcuboot/pull/765
mcuboot commit: 42335be22bc8fb576845f41e6174f1921fcff5d9

A fix for mcumgr library in Zephyr v1.14 LTS is in progress here:
https://github.com/zephyrproject-rtos/zephyr/pull/26738

Note that previously this issue also affected the image upload command but
that has not been fixed in the code restructure in commit
8914f8755983bf5e08ce30a56e0c0660341978e5

Signed-off-by: Nick Ward <nick.ward@setec.com.au>