### PR TITLE
Add image upload support for flash erased at 0

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -154,6 +154,9 @@ int img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
                                  struct img_mgmt_upload_action *action,
                                  const char **errstr);
 
+#define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
+int img_mgmt_impl_erased_val(int slot, uint8_t *erased_val);
+
 int img_mgmt_impl_log_upload_start(int status);
 
 int img_mgmt_impl_log_upload_done(int status, const uint8_t *hashp);

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -527,6 +527,23 @@ img_mgmt_impl_swap_type(void)
     }
 }
 
+int
+img_mgmt_impl_erased_val(int slot, uint8_t *erased_val)
+{
+    const struct flash_area *fa;
+    int rc;
+
+    rc = flash_area_open(flash_area_id_from_image_slot(slot), &fa);
+    if (rc != 0) {
+      return MGMT_ERR_EUNKNOWN;
+    }
+
+    *erased_val = flash_area_erased_val(fa);
+    flash_area_close(fa);
+
+    return 0;
+}
+
 void
 img_mgmt_module_init(void)
 {


### PR DESCRIPTION
Add a new abstraction to the image port implementation to get the value a flash device is erased to, and update the image manager to expect the correct values when reading erased data at the image header, etc.