### PR TITLE
mynewt: Fix strncpy warning

### DIFF
--- a/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
+++ b/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
@@ -89,7 +89,8 @@ os_mgmt_impl_task_info(int idx, struct os_mgmt_task_info *out_info)
     out_info->oti_last_checkin = task->t_sanity_check.sc_checkin_last;
     out_info->oti_next_checkin = task->t_sanity_check.sc_checkin_last +
                                  task->t_sanity_check.sc_checkin_itvl;
-    strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name);
+    strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name - 1);
+    out_info->oti_name[sizeof out_info->oti_name - 1] = '\0';
 
     return 0;
 }


### PR DESCRIPTION
GCC complains about a strncpy call when build using build_profile speed.
This warning indicates a possible string truncation. The only proper
solution I could find was to decrease the buffer size and explicitly
set a zero byte.

Error: repos/apache-mynewt-mcumgr/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c: In function 'os_mgmt_impl_task_info':
repos/apache-mynewt-mcumgr/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c:92:5: error: 'strncpy' specified bound 32 equals destination size [-Werror=stringop-truncation]
   92 |     strncpy(out_info->oti_name, task->t_name, sizeof out_info->oti_name);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors