### PR TITLE
mgmt: Uninitialized prev pointer may cause compilation warnings

### DIFF
--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -74,7 +74,7 @@ mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf)
 void
 mgmt_unregister_group(struct mgmt_group *group)
 {
-    struct mgmt_group *curr = mgmt_group_list, *prev;
+    struct mgmt_group *curr = mgmt_group_list, *prev = NULL;
 
     if (curr && curr == group) {
         mgmt_group_list = curr->mg_next;


### PR DESCRIPTION
Seen while compiling mcumgr with Zephyr: compilation claims possible
dereferencing of uninitialized prev pointer.
This is not possible situation as the dereferencing of prev depends on
curr pointer not being null, otherwise the code will exit prior to "faulty"
dereference.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>