### PR TITLE
Fix unitialized variable warning

### DIFF
--- a/mgmt/src/mgmt.c
+++ b/mgmt/src/mgmt.c
@@ -74,9 +74,13 @@ mgmt_streamer_free_buf(struct mgmt_streamer *streamer, void *buf)
 void
 mgmt_unregister_group(struct mgmt_group *group)
 {
-    struct mgmt_group *curr = mgmt_group_list, *prev;
+    struct mgmt_group *curr = mgmt_group_list, *prev = NULL;
 
-    if (curr && curr == group) {
+    if (!group) {
+        return;
+    }
+
+    if (curr == group) {
         mgmt_group_list = curr->mg_next;
         return;
     }
@@ -86,7 +90,7 @@ mgmt_unregister_group(struct mgmt_group *group)
         curr = curr->mg_next;
     }
 
-    if (!curr) {
+    if (!prev || !curr) {
         return;
     }
 


### PR DESCRIPTION
Fix usage of prev when curr==group, and add checking for invalid parameter. Fix issues found after #108 