### PR TITLE
Bug #18312 Add support for half-floats to MCUMGR

### DIFF
--- a/cborattr/include/cborattr/cborattr.h
+++ b/cborattr/include/cborattr/cborattr.h
@@ -48,6 +48,7 @@ typedef enum CborAttrType {
     CborAttrByteStringType,
     CborAttrTextStringType,
     CborAttrBooleanType,
+    CborAttrHalfFloatType,
     CborAttrFloatType,
     CborAttrDoubleType,
     CborAttrArrayType,
@@ -85,6 +86,9 @@ struct cbor_array_t {
         struct {
             double *store;
         } reals;
+        struct{
+            uint16_t *store;
+        } halffloats;
         struct {
             bool *store;
         } booleans;
@@ -99,6 +103,7 @@ struct cbor_attr_t {
     union {
         long long int *integer;
         long long unsigned int *uinteger;
+        uint16_t *halffloat;
         double *real;
         float *fval;
         char *string;
@@ -116,6 +121,7 @@ struct cbor_attr_t {
         double real;
         bool boolean;
         float fval;
+        uint16_t halffloat;
     } dflt;
     size_t len;
     bool nodefault;
@@ -139,6 +145,7 @@ struct cbor_out_val_t {
         long long unsigned int uinteger;
         double real;
         float fval;
+        uint16_t halffloat;
         const char *string;
         bool boolean;
         struct {

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -67,6 +67,11 @@ valid_attr_type(CborType ct, CborAttrType at)
         }
 	break;
 #if FLOAT_SUPPORT
+    case CborAttrHalfFloatType:
+        if (ct == CborHalfFloatType) {
+            return 1;
+        }
+        break;
     case CborAttrFloatType:
         if (ct == CborFloatType) {
             return 1;
@@ -120,6 +125,9 @@ cbor_target_address(const struct cbor_attr_t *cursor,
             targetaddr = (char *)&cursor->addr.uinteger[offset];
             break;
 #if FLOAT_SUPPORT
+        case CborAttrHalfFloatType:
+            targetaddr = (char *)&cursor->addr.halffloat[offset];
+            break;
         case CborAttrFloatType:
             targetaddr = (char *)&cursor->addr.fval[offset];
             break;
@@ -180,6 +188,9 @@ cbor_internal_read_object(CborValue *root_value,
                     memcpy(lptr, &cursor->dflt.boolean, sizeof(bool));
                     break;
 #if FLOAT_SUPPORT
+                case CborAttrHalfFloatType:
+                    memcpy(lptr, &cursor->dflt.halffloat, sizeof(uint16_t));
+                    break;
                 case CborAttrFloatType:
                     memcpy(lptr, &cursor->dflt.fval, sizeof(float));
                     break;
@@ -261,6 +272,9 @@ cbor_internal_read_object(CborValue *root_value,
                 err |= cbor_value_get_uint64(&cur_value, lptr);
                 break;
 #if FLOAT_SUPPORT
+            case CborAttrHalfFloatType:
+                err |= cbor_value_get_half_float(&cur_value, lptr);
+                break;
             case CborAttrFloatType:
                 err |= cbor_value_get_float(&cur_value, lptr);
                 break;
@@ -332,6 +346,10 @@ cbor_read_array(struct CborValue *value, const struct cbor_array_t *arr)
             err |= cbor_value_get_uint64(&elem, lptr);
             break;
 #if FLOAT_SUPPORT
+        case CborAttrHalfFloatType:
+            lptr = &arr->arr.halffloats.store[off];
+            err |= cbor_value_get_half_float(&elem, lptr);
+            break;
         case CborAttrFloatType:
         case CborAttrDoubleType:
             lptr = &arr->arr.reals.store[off];
@@ -491,6 +509,10 @@ cbor_write_val(struct CborEncoder *enc, const struct cbor_out_val_t *val)
         break;
 
 #if FLOAT_SUPPORT
+    case CborAttrHalfFloatType:
+        rc = cbor_encode_half_float(enc, val->halffloat);
+        break;
+
     case CborAttrFloatType:
         rc = cbor_encode_float(enc, val->fval);
         break;


### PR DESCRIPTION
This PR adds half-float support to MCUMGR.

We are using MCUMGR to transfer floating-point data
to our device and have found this can be transferred
as half, single or double precision float depending upon
the value being transferred.

Requested by: Greg Leach <greg.leach@lairdconnect.com>