### PR TITLE
Fix encoding usage for halffloat

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -510,7 +510,7 @@ cbor_write_val(struct CborEncoder *enc, const struct cbor_out_val_t *val)
 
 #if FLOAT_SUPPORT
     case CborAttrHalfFloatType:
-        rc = cbor_encode_half_float(enc, val->halffloat);
+        rc = cbor_encode_half_float(enc, &val->halffloat);
         break;
 
     case CborAttrFloatType:


### PR DESCRIPTION
`cbor_encode_half_float` was being called passing in the halffloat (uint16_t) by value, but `cbor_encode_floating_point` accepts a `void *` pointer. This is already done automatically for float and double encoding, but must be done manually for halffloat.

Fixes the current CI issues seen on nimble and core.