### PR TITLE
Support for software update to Direct-XIP built applications

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -32,13 +32,41 @@
 
 #elif defined __ZEPHYR__
 
+#include <devicetree.h>
+
 #define IMG_MGMT_UL_CHUNK_SIZE  CONFIG_IMG_MGMT_UL_CHUNK_SIZE
 #define IMG_MGMT_VERBOSE_ERR    CONFIG_IMG_MGMT_VERBOSE_ERR
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
-#define IMG_MGMT_BOOT_CURR_SLOT 0
 
+#define DT_CODE_PARTITION_NODE DT_CHOSEN(zephyr_code_partition)
+#define DT_IMAGE_0_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(image_0)
+#define DT_IMAGE_1_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(image_1)
+#define DT_IMAGE_0_NS_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(image_0_nonsecure)
+#define DT_IMAGE_1_NS_NODE DT_NODE_BY_FIXED_PARTITION_LABEL(image_1_nonsecure)
+
+#define IS_IMAGE_CODE_PARTITION(image) \
+        DT_SAME_NODE(DT_CODE_PARTITION_NODE, image)
+
+#if IS_IMAGE_CODE_PARTITION(DT_IMAGE_0_NODE)
+#define IMG_MGMT_BOOT_CURR_SLOT 0
+#elif IS_IMAGE_CODE_PARTITION(DT_IMAGE_1_NODE)
+#define IMG_MGMT_BOOT_CURR_SLOT 1
+#elif IS_IMAGE_CODE_PARTITION(DT_IMAGE_0_NS_NODE)
+#define IMG_MGMT_BOOT_CURR_SLOT 0
+#elif IS_IMAGE_CODE_PARTITION(DT_IMAGE_1_NS_NODE)
+#define IMG_MGMT_BOOT_CURR_SLOT 1
 #else
+#error "Could not determine active slot from zephyr,code-partition"
+#endif
+
+/* Undef all macros that are not needed at this point */
+#undef DT_CODE_PARTITION_NODE
+#undef DT_IMAGE_0_NODE
+#undef DT_IMAGE_1_NODE
+#undef DT_IMAGE_0_NS_NODE
+#undef DT_IMAGE_1_NS_NODE
+#undef IS_IMAGE_CODE_PARTITION
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -400,6 +400,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 int
 img_mgmt_impl_swap_type(void)
 {
+#if !defined(CONFIG_IMG_MGMT_DIRECT_XIP)
     switch (mcuboot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;
@@ -411,8 +412,9 @@ img_mgmt_impl_swap_type(void)
         return IMG_MGMT_SWAP_TYPE_REVERT;
     default:
         assert(0);
-        return IMG_MGMT_SWAP_TYPE_NONE;
     }
+#endif
+    return IMG_MGMT_SWAP_TYPE_NONE;
 }
 
 /**


### PR DESCRIPTION
Depends on https://github.com/apache/mynewt-mcumgr/pull/114

The PR contains two PRs that
 1)  Add automatic selection of running application slot at compile time
 2) Remove restrictions on uploading applications to "pending" slots for Direct-XIP applications
