### PR TITLE
img_mgmt_state_set_pending: corrected error handling

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -143,18 +143,19 @@ img_mgmt_state_set_pending(int slot, int permanent)
 
 done:
     /* Log the image hash if we know it. */
-    rc = img_mgmt_read_info(slot, NULL, hash, NULL);
-    if (rc != 0) {
+    if (img_mgmt_read_info(slot, NULL, hash, NULL)) {
         hashp = NULL;
     } else {
         hashp = hash;
     }
 
     if (permanent) {
-        return img_mgmt_impl_log_confirm(rc, hashp);
+        (void) img_mgmt_impl_log_confirm(rc, hashp);
     } else {
-        return img_mgmt_impl_log_pending(rc, hashp);
+        (void) img_mgmt_impl_log_pending(rc, hashp);
     }
+
+    return rc;
 }
 
 /**


### PR DESCRIPTION
rc assigns were leftover of state before adding `done:` marker. They
were not used as actual return values no more, as first thing that
happens at done marker is overwrite of them