### PR TITLE
samples: smp_svr: zephyr: Update MTU Kconfig values

### DIFF
--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -8,7 +8,8 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_L2CAP_TX_MTU=252
+CONFIG_BT_L2CAP_RX_MTU=252
 CONFIG_BT_RX_BUF_LEN=260
 
 # Enable the Bluetooth (unauthenticated) and shell mcumgr transports.

--- a/samples/smp_svr/zephyr/prj_tiny.conf
+++ b/samples/smp_svr/zephyr/prj_tiny.conf
@@ -12,7 +12,8 @@ CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
 CONFIG_BOOTLOADER_MCUBOOT=y
 
 # Allow for large Bluetooth data packets.
-CONFIG_BT_L2CAP_TX_MTU=260
+CONFIG_BT_L2CAP_TX_MTU=252
+CONFIG_BT_L2CAP_RX_MTU=252
 CONFIG_BT_RX_BUF_LEN=260
 
 # Enable the Bluetooth (unauthenticated) and UART mcumgr transports.


### PR DESCRIPTION
The usage of theses kconfig have changed in
zephyrproject-rtos/zephyr#26447

Hence their values should be updated.

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>