### PR TITLE
img_mgmt: Add interpretation of "image" parameter

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -74,6 +74,7 @@ extern struct img_mgmt_state g_img_mgmt_state;
 
 /** Represents an individual upload request. */
 struct img_mgmt_upload_req {
+    unsigned long long int image;   /* 0 by default */
     unsigned long long int off;     /* -1 if unspecified */
     unsigned long long int size;    /* -1 if unspecified */
     size_t data_len;

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -394,42 +394,49 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
         .data_len = 0,
         .data_sha_len = 0,
         .upgrade = false,
+        .image = 0,
     };
 
     const struct cbor_attr_t off_attr[] = {
         [0] = {
+            .attribute = "image",
+            .type = CborAttrUnsignedIntegerType,
+            .addr.uinteger = &req.image,
+            .nodefault = true
+        },
+        [1] = {
             .attribute = "data",
             .type = CborAttrByteStringType,
             .addr.bytestring.data = req.img_data,
             .addr.bytestring.len = &req.data_len,
             .len = sizeof(req.img_data)
         },
-        [1] = {
+        [2] = {
             .attribute = "len",
             .type = CborAttrUnsignedIntegerType,
             .addr.uinteger = &req.size,
             .nodefault = true
         },
-        [2] = {
+        [3] = {
             .attribute = "off",
             .type = CborAttrUnsignedIntegerType,
             .addr.uinteger = &req.off,
             .nodefault = true
         },
-        [3] = {
+        [4] = {
             .attribute = "sha",
             .type = CborAttrByteStringType,
             .addr.bytestring.data = req.data_sha,
             .addr.bytestring.len = &req.data_sha_len,
             .len = sizeof(req.data_sha)
         },
-        [4] = {
+        [5] = {
             .attribute = "upgrade",
             .type = CborAttrBooleanType,
             .addr.boolean = &req.upgrade,
             .dflt.boolean = false,
         },
-        [5] = { 0 },
+        [6] = { 0 },
     };
     int rc;
     const char *errstr = NULL;


### PR DESCRIPTION
The commit extends img_mgmt_upload_req with image member that will
be used to hold image number; it also adds code that picks the
image number from update frame.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>