### PR TITLE
Zephyr fixes

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -292,7 +292,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 			}
 		}
 #endif
-		rc = flash_img_init_id(ctx, img_mgmt_find_best_area_id());
+		rc = flash_img_init_id(ctx, g_img_mgmt_state.area_id);
 
 		if (rc != 0) {
 			return MGMT_ERR_EUNKNOWN;
@@ -330,7 +330,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
         goto end;
     }
 
-    rc = flash_area_open(img_mgmt_find_best_area_id(), &fa);
+    rc = flash_area_open(g_img_mgmt_state.area_id, &fa);
     if (rc != 0) {
         LOG_ERR("Can't bind to the flash area (err %d)", rc);
         rc = MGMT_ERR_EUNKNOWN;

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -192,11 +192,13 @@ int
 img_mgmt_impl_erase_slot(void)
 {
     bool empty;
-    int rc;
+    int rc, best_id;
 
     /* Select non-active slot */
-    const int best_id = img_mgmt_find_best_area_id();
-
+    best_id = img_mgmt_find_best_area_id();
+    if (best_id < 0) {
+        return MGMT_ERR_EUNKNOWN;
+    }
     rc = zephyr_img_mgmt_flash_check_empty(best_id, &empty);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;


### PR DESCRIPTION
The PR is series of fixes that to the Zephyr fork that:
 - change slot selection logic of `img_mgmt_find_best_area_id`, renames it to `mgm_mgmt_get_unused_area_id` and adds single parameter; now the function will accept as -1 as a parameter that request any upgreadable slot area_id, selected from first two slots, or positive number that is direct slot request; direct slot request may not be successful for first two slots as they are checked for usage, while no such checks are performed for all other slots.  All other slots are just checked for existence.
 - add missing check, of `img_mgmt_get_second_slot_area_id` return, in `img_mgmt_impl_erase_slot`;
 - changes the `img_mgmt_impl_write_image_data` to use the `area_id` from the state of mcumgr, so the currently selected for operation, instead of calling `img_mgmt_get_second_slot_area_id` (formerly `img_mgmt_find_best_area_id`) to figure it out again.