### PR TITLE
cmd/img_mgmt: Call dfu stop cb on erase

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -314,6 +314,10 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
     
     rc = img_mgmt_impl_erase_slot();
 
+    if (!rc) {
+        img_mgmt_dfu_stopped();
+    }
+
     err = 0;
     err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
     err |= cbor_encode_int(&ctxt->encoder, rc);


### PR DESCRIPTION
- DFU stop callback needs to be called when erase is performed, since the DFU state of the image gets cleared