### PR TITLE
samples/smp_svr/zephyr: Update stack size

### DIFF
--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -2,7 +2,7 @@
 CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y

--- a/samples/smp_svr/zephyr/prj_tiny.conf
+++ b/samples/smp_svr/zephyr/prj_tiny.conf
@@ -6,7 +6,7 @@
 CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
-CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2048
+CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
The addition of image interpretation requires increase in stack
size.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>