### PR TITLE
cmd: img_mgmt: Add multi-image support in img_mgmt/_state

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -20,6 +20,9 @@
 #ifndef H_IMG_MGMT_CONFIG_
 #define H_IMG_MGMT_CONFIG_
 
+/* Number of updatable images */
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER 1
+
 #if defined MYNEWT
 
 #include "syscfg/syscfg.h"
@@ -38,7 +41,10 @@
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
 
-#else
+#if defined(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER)
+#undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#endif
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -105,6 +105,15 @@ int img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 int img_mgmt_impl_swap_type(void);
 
 /**
+ * @brief Indicates the type of swap operation that will occur on the next
+ * reboot, if any.
+ * @param  slot                 The slot to read swap type from.
+ *
+ * @return                      An IMG_MGMT_SWAP_TYPE_[...] code.
+ */
+int img_mgmt_impl_swap_type_multi(int slot);
+
+/**
  * Collects information about the specified image slot.
  *
  * @return                      Flags of the specified image slot

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -36,6 +36,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <img_mgmt/image.h>
 #include "../../../src/img_mgmt_priv.h"
 
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
 static int
 slot_to_image_index(int slot)
 {
@@ -43,10 +44,11 @@ slot_to_image_index(int slot)
 	    return 0;
     } else if (slot < 4) {
 	    return 1;
-    else {
+    } else {
 	    return -1;
     }
 }
+#endif
 
 /**
  * Determines if the specified area of flash is completely unwritten.
@@ -428,6 +430,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 }
 #endif
 
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
 int
 img_mgmt_impl_swap_type_multi(int slot)
 {
@@ -445,6 +448,7 @@ img_mgmt_impl_swap_type_multi(int slot)
         return IMG_MGMT_SWAP_TYPE_NONE;
     }
 }
+#endif
 
 int
 img_mgmt_impl_swap_type(void)

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -248,7 +248,7 @@ img_mgmt_impl_write_pending(int slot, bool permanent)
         return MGMT_ERR_EINVAL;
     }
 
-#if CONFIG_UPDATEABLE_IMAGE_NUMBER > 1
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
     rc = boot_request_upgrade_multi(slot_to_image_index(slot), permanent);
 #else
     rc = boot_request_upgrade(permanent);

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -241,7 +241,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
     int i;
     struct image_version ver;
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
             continue;
         }
@@ -262,7 +262,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
     int i;
     uint8_t hash[IMAGE_HASH_LEN];
 
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
             continue;
         }

--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -241,7 +241,7 @@ img_mgmt_find_by_ver(struct image_version *find, uint8_t *hash)
     int i;
     struct image_version ver;
 
-    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, &ver, hash, NULL) != 0) {
             continue;
         }
@@ -262,7 +262,7 @@ img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver)
     int i;
     uint8_t hash[IMAGE_HASH_LEN];
 
-    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         if (img_mgmt_read_info(i, ver, hash, NULL) != 0) {
             continue;
         }

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -44,7 +44,7 @@ img_mgmt_state_flags(int query_slot)
     /* Determine if this is is pending or confirmed (only applicable for
      * unified images and loaders.
      */
-#if CONFIG_UPDATEABLE_IMAGE_NUMBER > 1
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 1
     swap_type = img_mgmt_impl_swap_type_multi(query_slot);
 #else
     swap_type = img_mgmt_impl_swap_type();
@@ -210,7 +210,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 
     err |= cbor_encoder_create_array(&ctxt->encoder, &images,
                                        CborIndefiniteLength);
-    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
+    for (i = 0; i < 2 * IMG_MGMT_UPDATABLE_IMAGE_NUMBER; i++) {
         rc = img_mgmt_read_info(i, &ver, hash, &flags);
         if (rc != 0) {
             continue;

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -36,14 +36,19 @@ img_mgmt_state_flags(int query_slot)
     uint8_t flags;
     int swap_type;
 
-    assert(query_slot == 0 || query_slot == 1);
+    assert(query_slot == 0 || query_slot == 1 ||
+           query_slot == 2 || query_slot == 3);
 
     flags = 0;
 
     /* Determine if this is is pending or confirmed (only applicable for
      * unified images and loaders.
      */
+#if CONFIG_UPDATEABLE_IMAGE_NUMBER > 1
+    swap_type = img_mgmt_impl_swap_type_multi(query_slot);
+#else
     swap_type = img_mgmt_impl_swap_type();
+#endif
     switch (swap_type) {
     case IMG_MGMT_SWAP_TYPE_NONE:
         if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
@@ -205,7 +210,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 
     err |= cbor_encoder_create_array(&ctxt->encoder, &images,
                                        CborIndefiniteLength);
-    for (i = 0; i < 2; i++) {
+    for (i = 0; i < 2*CONFIG_UPDATEABLE_IMAGE_NUMBER; i++) {
         rc = img_mgmt_read_info(i, &ver, hash, &flags);
         if (rc != 0) {
             continue;


### PR DESCRIPTION
Add multi-image support in img_mgmt for zephyr and general
implementations. By setting the `CONFIG_UPDATEABLE_IMAGE_NUMBER` it will
iterate over more images and use `_multi` implementations in zephyr.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>