### PR TITLE
Parametrize img_mgmt_impl_swap_type

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -98,11 +98,13 @@ int img_mgmt_impl_write_image_data(unsigned int offset, const void *data,
 
 /**
  * @brief Indicates the type of swap operation that will occur on the next
- * reboot, if any.
+ * reboot, if any, between provided slot and it's pair.
+ * Quering any slots of the same pair will give the same result.
  *
+ * @param image                 An slot number;
  * @return                      An IMG_MGMT_SWAP_TYPE_[...] code.
  */
-int img_mgmt_impl_swap_type(void);
+int img_mgmt_impl_swap_type(int slot);
 
 /**
  * Collects information about the specified image slot.

--- a/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
+++ b/cmd/img_mgmt/port/mynewt/src/mynewt_img_mgmt.c
@@ -510,8 +510,10 @@ done:
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
+    assert(slot == 0 || slot == 1);
+
     switch (boot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:
         return IMG_MGMT_SWAP_TYPE_NONE;

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -413,7 +413,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
 #endif
 
 int
-img_mgmt_impl_swap_type(void)
+img_mgmt_impl_swap_type(int slot)
 {
     switch (mcuboot_swap_type()) {
     case BOOT_SWAP_TYPE_NONE:

--- a/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/cmd/img_mgmt/src/img_mgmt_state.c
@@ -36,14 +36,12 @@ img_mgmt_state_flags(int query_slot)
     uint8_t flags;
     int swap_type;
 
-    assert(query_slot == 0 || query_slot == 1);
-
     flags = 0;
 
     /* Determine if this is is pending or confirmed (only applicable for
      * unified images and loaders.
      */
-    swap_type = img_mgmt_impl_swap_type();
+    swap_type = img_mgmt_impl_swap_type(query_slot);
     switch (swap_type) {
     case IMG_MGMT_SWAP_TYPE_NONE:
         if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {


### PR DESCRIPTION
The PR contains series of commits that add slot parameter to `img_mgmt_impl_swap_type` and change system ports to support it.
It also moves slot number checking asserts to system specific implementation of the `img_mgmt_impl_swap_type`.