### PR TITLE
img_mgmt: fix callback parameter values

### DIFF
--- a/cmd/img_mgmt/src/img_mgmt.c
+++ b/cmd/img_mgmt/src/img_mgmt.c
@@ -515,6 +515,8 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
             }
         }
 #endif
+    } else {
+        cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_ONGOING;
     }
 
     /* Write the image data to flash. */
@@ -542,7 +544,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
             if (g_img_mgmt_state.off == g_img_mgmt_state.size) {
                 /* Done */
                 img_mgmt_dfu_pending();
-                cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_ONGOING;
+                cmd_status_arg.status = IMG_MGMT_ID_UPLOAD_STATUS_COMPLETE;
                 g_img_mgmt_state.area_id = -1;
             }
         }


### PR DESCRIPTION
Start, ongoing and complete states are now used in the callback

Signed-off-by: Jamie McCrae <jamie.mccrae@lairdconnect.com>

Fixes https://github.com/apache/mynewt-mcumgr/issues/136

Output from callback in a zephyr application after these changes:
```
[00:02:04.021,718] <err> Got callback: 2, 1, 1, 0
[00:02:28.120,300] <err> Got callback: 2, 1, 1, 1
[00:02:28.260,223] <err> Got callback: 2, 1, 1, 1
[00:02:28.300,292] <err> Got callback: 2, 1, 1, 1
[00:02:28.330,291] <err> Got callback: 2, 1, 1, 1
[00:02:28.370,666] <err> Got callback: 2, 1, 1, 1
[00:02:28.405,303] <err> Got callback: 2, 1, 1, 1
[00:02:28.444,946] <err> Got callback: 2, 1, 1, 1
[00:02:28.480,316] <err> Got callback: 2, 1, 1, 1
[00:02:28.510,314] <err> Got callback: 2, 1, 1, 1
[00:02:28.549,560] <err> Got callback: 2, 1, 1, 1
[00:02:28.689,636] <err> Got callback: 2, 1, 1, 2
```