### PR TITLE
zephyr: Fix erase command failing for multi-image configuration

### DIFF
--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -205,7 +205,7 @@ img_mgmt_get_unused_slot_area_id(int image)
 {
     int area_id = -1;
 
-    if (image == 0) {
+    if (image == 0 || image == -1) {
         if (img_mgmt_slot_in_use(1) == 0) {
             area_id = zephyr_img_mgmt_flash_area_id(1);
         }


### PR DESCRIPTION
The img_mgmt_get_unused_slot_area_id has been incorrectly
reacting to -1 parameter, which is valid parameter for single
image configuration.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>