### PR TITLE
zephyr: Do not use CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER directly

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -40,8 +40,12 @@
 #define IMG_MGMT_LAZY_ERASE     CONFIG_IMG_ERASE_PROGRESSIVELY
 #define IMG_MGMT_DUMMY_HDR      CONFIG_IMG_MGMT_DUMMY_HDR
 #define IMG_MGMT_BOOT_CURR_SLOT 0
+#ifdef CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+/* Up to two images are supported */
+BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 2, "Unsupported number of images");
 #undef IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
+#endif
 
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -36,8 +36,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <img_mgmt/image.h>
 #include "../../../src/img_mgmt_priv.h"
 
-BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1 ||
-             (CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 &&
+BUILD_ASSERT(IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1 ||
+             (IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 &&
               FLASH_AREA_LABEL_EXISTS(image_2) &&
               FLASH_AREA_LABEL_EXISTS(image_3)),
               "Missing partitions?");
@@ -153,7 +153,7 @@ zephyr_img_mgmt_flash_area_id(int slot)
     return fa_id;
 }
 
-#if CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1
+#if IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1
 /**
  * In normal operation this function will select between first two slot
  * (in reality it just checks whether second slot can be used), ignoring the
@@ -199,7 +199,7 @@ img_mgmt_get_unused_slot_area_id(int slot)
     return slot != -1  ? zephyr_img_mgmt_flash_area_id(slot) : -1;
 #endif
 }
-#elif CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2
+#elif IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2
 static int
 img_mgmt_get_unused_slot_area_id(int image)
 {
@@ -289,7 +289,7 @@ img_mgmt_impl_write_pending(int slot, bool permanent)
     int rc;
 
     if (slot != 1 &&
-        !(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 && slot == 3)) {
+        !(IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 2 && slot == 3)) {
         return MGMT_ERR_EINVAL;
     }
 


### PR DESCRIPTION
The IMG_MGMT_UPDATABLE_IMAGE_NUMBER should be used in
then CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER; this allows defaulting
IMG_MGMT_UPDATABLE_IMAGE_NUMBER when the config option is not defined
and avoid compilation errors.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>