### PR TITLE
samples/smp_svr/zephyr: Increase main stack size

### DIFF
--- a/samples/smp_svr/zephyr/prj.conf
+++ b/samples/smp_svr/zephyr/prj.conf
@@ -3,6 +3,7 @@ CONFIG_MCUMGR=y
 
 # Some command handlers require a large stack.
 CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE=2304
+CONFIG_MAIN_STACK_SIZE=2048
 
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y


### PR DESCRIPTION
Some build variants will fail runtime due to stack
overflow. Avoid this by increasing the stack size.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>