### PR TITLE
Fix missing else in configuration

### DIFF
--- a/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
+++ b/cmd/img_mgmt/include/img_mgmt/img_mgmt_config.h
@@ -47,9 +47,12 @@ BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER > 2, "Unsupported number of 
 #define IMG_MGMT_UPDATABLE_IMAGE_NUMBER CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 #endif
 
+#else
+
 /* No direct support for this OS.  The application needs to define the above
  * settings itself.
  */
+#error "Unknown OS/missing configuration"
 
 #endif
 


### PR DESCRIPTION
The #else has been missing in system dependent definitions for image
management configuration; the commit adds the missing else and
an error message when compilation is run on system for which
configuration has not been provided.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>