### PR TITLE
cborattr: fixes missing error handling

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -306,7 +306,7 @@ cbor_internal_read_object(CborValue *root_value,
                 err |= CborErrorIllegalType;
             }
         }
-        cbor_value_advance(&cur_value);
+        err = cbor_value_advance(&cur_value);
     }
     if (!err) {
         /* that should be it for this container */


### PR DESCRIPTION
In the while loop in the function cbor_internal_read_object
there is no error handling when the cbor_value_advance
reports an error. This may end up in a never ending loop.

This seems to be fixing the issue reported in https://github.com/apache/mynewt-mcumgr/issues/140

Signed-off-by: Even Falch-Larsen <even.falch.larsen@nomono.co>