### PR TITLE
os_mgmt/mynewt: Make package dependency conditional

### DIFF
--- a/cmd/os_mgmt/port/mynewt/pkg.yml
+++ b/cmd/os_mgmt/port/mynewt/pkg.yml
@@ -26,4 +26,5 @@ pkg.keywords:
 pkg.deps:
     - '@apache-mynewt-mcumgr/cmd/os_mgmt'
     - '@apache-mynewt-mcumgr/mgmt'
+pkg.deps.LOG_SOFT_RESET:
     - '@apache-mynewt-core/sys/reboot'


### PR DESCRIPTION
Code already  uses sys/reboot only if LOG_SOFT_RESET is enabled.
Now package is also included only if LOG_SOFT_RESET is present,
this removes unnecessary package inclusion that result in
requirement to have reboot log image area that package will
not use when flag is not present.