### PR TITLE
os_mgmt/mynewt: Fix build when LOG_SOFT_RESET is off

### DIFF
--- a/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
+++ b/cmd/os_mgmt/port/mynewt/src/mynewt_os_mgmt.c
@@ -22,11 +22,11 @@
 #include "os/os.h"
 #if MYNEWT_VAL(LOG_SOFT_RESET)
 #include "reboot/log_reboot.h"
+#include "img_mgmt/img_mgmt.h"
 #endif
 #include "os_mgmt/os_mgmt_impl.h"
 #include "os_mgmt/os_mgmt.h"
 #include "mgmt/mgmt.h"
-#include "img_mgmt/img_mgmt.h"
 
 static struct os_callout mynewt_os_mgmt_reset_callout;
 


### PR DESCRIPTION
package @apache-mynewt-mcumgr/cmd/img_mgmt is only
used when LOG_SOFT_RESET is defined.

This change moves #include to line to remove build error
when LOG_SOFT_RESET is 0.