### PR TITLE
os_mgmt/mynewt: Fix log reboot confusion

### DIFF
--- a/cmd/os_mgmt/port/mynewt/syscfg.yml
+++ b/cmd/os_mgmt/port/mynewt/syscfg.yml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+syscfg.defs:
+    LOG_SOFT_RESET:
+        description: >
+            Log soft resets.
+        value: 1


### PR DESCRIPTION
LOG_SOFT_REBOOT was defined in sys/reboot package.
This package however never used this for anything.
Moreover, some packages in mynewt-core used this
value to conditionally include sys/reboot.

Now LOG_SOFT_REBOOT is moved to package that actually
uses it for inclusion of sys/reboot.

related PR in mynewt-core: https://github.com/apache/mynewt-core/pull/2710