### PR TITLE
zephyr: update include paths to use <zephyr/...>

### DIFF
--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -22,7 +22,7 @@
 #include "tinycbor/cbor_buf_reader.h"
 
 #ifdef __ZEPHYR__
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #ifdef CONFIG_MGMT_CBORATTR_MAX_SIZE
 #define CBORATTR_MAX_SIZE CONFIG_MGMT_CBORATTR_MAX_SIZE
 #else

--- a/cborattr/src/cborattr.c
+++ b/cborattr/src/cborattr.c
@@ -22,7 +22,7 @@
 #include "tinycbor/cbor_buf_reader.h"
 
 #ifdef __ZEPHYR__
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #ifdef CONFIG_MGMT_CBORATTR_MAX_SIZE
 #define CBORATTR_MAX_SIZE CONFIG_MGMT_CBORATTR_MAX_SIZE
 #else

--- a/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/zephyr/src/zephyr_fs_mgmt.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <fs/fs.h>
+#include <zephyr/fs/fs.h>
 #include <mgmt/mgmt.h>
 #include <fs_mgmt/fs_mgmt_impl.h>
 

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -19,17 +19,17 @@
 
 #define LOG_MODULE_NAME mcumgr_flash_mgmt
 #define LOG_LEVEL CONFIG_IMG_MANAGER_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 #include <assert.h>
-#include <drivers/flash.h>
-#include <storage/flash_map.h>
-#include <zephyr.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/zephyr.h>
 #include <soc.h>
-#include <init.h>
-#include <dfu/mcuboot.h>
-#include <dfu/flash_img.h>
+#include <zephyr/init.h>
+#include <zephyr/dfu/mcuboot.h>
+#include <zephyr/dfu/flash_img.h>
 #include <mgmt/mgmt.h>
 #include <img_mgmt/img_mgmt_impl.h>
 #include <img_mgmt/img_mgmt.h>

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #include <assert.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/storage/flash_map.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include <zephyr/init.h>
 #include <zephyr/dfu/mcuboot.h>

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt_log.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt_log.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <img_mgmt/img_mgmt.h>
 /**
  * Log event types (all events are CBOR-encoded):

--- a/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt_log.c
+++ b/cmd/img_mgmt/port/zephyr/src/zephyr_img_mgmt_log.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <img_mgmt/img_mgmt.h>
 /**
  * Log event types (all events are CBOR-encoded):

--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <power/reboot.h>
-#include <debug/object_tracing.h>
-#include <kernel_structs.h>
+#include <zephyr/debug/object_tracing.h>
+#include <zephyr/kernel_structs.h>
 #include <mgmt/mgmt.h>
 #include <util/mcumgr_util.h>
 #include <os_mgmt/os_mgmt.h>

--- a/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
+++ b/cmd/os_mgmt/port/zephyr/src/zephyr_os_mgmt.c
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <power/reboot.h>
 #include <zephyr/debug/object_tracing.h>
 #include <zephyr/kernel_structs.h>

--- a/cmd/shell_mgmt/port/zephyr/src/zephyr_shell_mgmt.c
+++ b/cmd/shell_mgmt/port/zephyr/src/zephyr_shell_mgmt.c
@@ -17,11 +17,11 @@
  * under the License.
  */
 
-#include <sys/util.h>
-#include <shell/shell.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/shell/shell.h>
 #include <mgmt/mgmt.h>
 #include <shell_mgmt/shell_mgmt.h>
-#include <shell/shell_dummy.h>
+#include <zephyr/shell/shell_dummy.h>
 
 int
 shell_mgmt_impl_exec(const char *line)

--- a/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
+++ b/cmd/stat_mgmt/port/zephyr/src/zephyr_stat_mgmt.c
@@ -17,8 +17,8 @@
  * under the License.
  */
 
-#include <sys/util.h>
-#include <stats/stats.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/stats/stats.h>
 #include <mgmt/mgmt.h>
 #include <stat_mgmt/stat_mgmt.h>
 #include <stat_mgmt/stat_mgmt_impl.h>

--- a/samples/smp_svr/zephyr/src/main.c
+++ b/samples/smp_svr/zephyr/src/main.c
@@ -18,17 +18,17 @@
  */
 
 #include <assert.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
 #include <stdlib.h>
-#include <stats/stats.h>
+#include <zephyr/stats/stats.h>
 #include <mgmt/buf.h>
 
 #ifdef CONFIG_MCUMGR_CMD_FS_MGMT
-#include <device.h>
-#include <fs/fs.h>
+#include <zephyr/device.h>
+#include <zephyr/fs/fs.h>
 #include "fs_mgmt/fs_mgmt.h"
-#include <fs/littlefs.h>
+#include <zephyr/fs/littlefs.h>
 #endif
 #ifdef CONFIG_MCUMGR_CMD_OS_MGMT
 #include "os_mgmt/os_mgmt.h"
@@ -41,9 +41,9 @@
 #endif
 
 #ifdef CONFIG_MCUMGR_SMP_BT
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
 #include <mgmt/smp_bt.h>
 #endif
 

--- a/samples/smp_svr/zephyr/src/main.c
+++ b/samples/smp_svr/zephyr/src/main.c
@@ -18,7 +18,7 @@
  */
 
 #include <assert.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <stdlib.h>
 #include <zephyr/stats/stats.h>


### PR DESCRIPTION
Zephyr has prefixed all of its includes with <zephyr/...>. While the old
mode can still be used (CONFIG_LEGACY_INCLUDE_PATH) and is still enabled
by default, it's better to be prepared for its removal in the future.