### PR TITLE
Use syscfg settings for sysinit stage numbers

### DIFF
--- a/cmd/img_mgmt/port/mynewt/pkg.yml
+++ b/cmd/img_mgmt/port/mynewt/pkg.yml
@@ -29,4 +29,4 @@ pkg.deps:
     - '@apache-mynewt-core/sys/log/modlog'
 
 pkg.init:
-    img_mgmt_module_init: 501
+    img_mgmt_module_init: 'MYNEWT_VAL(IMG_MGMT_SYSINIT_STAGE)'

--- a/cmd/img_mgmt/port/mynewt/syscfg.yml
+++ b/cmd/img_mgmt/port/mynewt/syscfg.yml
@@ -23,6 +23,9 @@ syscfg.defs:
     IMG_MGMT_LOG_LVL:
         description: 'Minimum level for the image management structured log.'
         value: 15  # Log disabled by default.
+    IMG_MGMT_SYSINIT_STAGE:
+        description: System initalization stage for IMG_MGMT package
+        value: 501
 
 syscfg.logs:
     IMG_MGMT_LOG:

--- a/cmd/log_mgmt/port/mynewt/syscfg.yml
+++ b/cmd/log_mgmt/port/mynewt/syscfg.yml
@@ -37,6 +37,11 @@ syscfg.defs:
             management commands.
         value: 64
 
+    LOG_MGMT_SYSINIT_STAGE:
+          description: >
+              System Initalization stage for LOG MGMT package
+          value: 501
+
 # For backwards compatibility with log nmgr
 syscfg.vals.LOG_NMGR_MAX_RSP_LEN:
     LOG_MGMT_MAX_RSP_SIZE: MYNEWT_VAL(LOG_NMGR_MAX_RSP_LEN)

--- a/cmd/os_mgmt/pkg.yml
+++ b/cmd/os_mgmt/pkg.yml
@@ -33,4 +33,4 @@ pkg.ign_files:
     - "stubs.c"
 
 pkg.init:
-    os_mgmt_module_init: 501
+    os_mgmt_module_init: 'MYNEWT_VAL(OS_MGMT_SYSINIT_STAGE)'

--- a/cmd/os_mgmt/syscfg.yml
+++ b/cmd/os_mgmt/syscfg.yml
@@ -34,3 +34,8 @@ syscfg.defs:
         description: >
             Enable support for echo command.
         value: 1
+
+    OS_MGMT_SYSINIT_STAGE:
+        description: >
+            System Initialization stage for OS_MGMT package
+        value: 501

--- a/cmd/stat_mgmt/port/mynewt/pkg.yml
+++ b/cmd/stat_mgmt/port/mynewt/pkg.yml
@@ -28,4 +28,4 @@ pkg.deps:
     - '@apache-mynewt-mcumgr/mgmt'
 
 pkg.init:
-    stat_mgmt_module_init: 501
+    stat_mgmt_module_init: 'MYNEWT_VAL(STAT_MGMT_SYSINIT_STAGE)'

--- a/cmd/stat_mgmt/port/mynewt/syscfg.yml
+++ b/cmd/stat_mgmt/port/mynewt/syscfg.yml
@@ -17,15 +17,8 @@
 # under the License.
 #
 
-pkg.name: cmd/log_mgmt/port/mynewt
-pkg.description: 'Log management command handlers for mcumgr.'
-pkg.author: "Apache Mynewt <dev@mynewt.apache.org>"
-pkg.homepage: "http://mynewt.apache.org/"
-pkg.keywords:
-
-pkg.deps:
-    - '@apache-mynewt-mcumgr/cmd/log_mgmt'
-    - '@apache-mynewt-mcumgr/mgmt'
-
-pkg.init:
-    log_mgmt_module_init: 'MYNEWT_VAL(LOG_MGMT_SYSINIT_STAGE)'
+syscfg.defs:
+    STAT_MGMT_SYSINIT_STAGE:
+        description: >
+            System Initialization stage for STAT_MGMT package
+        value: 501


### PR DESCRIPTION
This allows the app or target to rearrange package initialziation order via syscfg overrides