### PR TITLE
cborattr/test: Add type casting for 64-bit architecture

### DIFF
--- a/cborattr/test/src/testcases/cborattr_decode_int_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_int_array.c
@@ -83,7 +83,7 @@ TEST_CASE(test_cborattr_decode_int_array)
             .attribute = "a",
             .type = CborAttrArrayType,
             .addr.array.element_type = CborAttrIntegerType,
-            .addr.array.arr.integers.store = arr_data,
+            .addr.array.arr.integers.store = (long long int *) arr_data,
             .addr.array.count = &arr_cnt,
             .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
             .nodefault = true
@@ -91,7 +91,7 @@ TEST_CASE(test_cborattr_decode_int_array)
         [1] = {
             .attribute = "b",
             .type = CborAttrIntegerType,
-            .addr.integer = &b_int,
+            .addr.integer = (long long int *) &b_int,
             .dflt.integer = 1
         },
         [2] = {
@@ -103,7 +103,7 @@ TEST_CASE(test_cborattr_decode_int_array)
             .attribute = "a",
             .type = CborAttrArrayType,
             .addr.array.element_type = CborAttrIntegerType,
-            .addr.array.arr.integers.store = arr_data,
+            .addr.array.arr.integers.store = (long long int *) arr_data,
             .addr.array.count = &arr_cnt,
             .addr.array.maxlen = 1,
             .nodefault = true
@@ -111,7 +111,7 @@ TEST_CASE(test_cborattr_decode_int_array)
         [1] = {
             .attribute = "b",
             .type = CborAttrIntegerType,
-            .addr.integer = &b_int,
+            .addr.integer = (long long int *) &b_int,
             .dflt.integer = 1
         },
         [2] = {

--- a/cborattr/test/src/testcases/cborattr_decode_object.c
+++ b/cborattr/test/src/testcases/cborattr_decode_object.c
@@ -115,7 +115,7 @@ TEST_CASE(test_cborattr_decode_object)
         [0] = {
             .attribute = "bm",
             .type = CborAttrIntegerType,
-            .addr.integer = &bm_val,
+            .addr.integer = (long long int *) &bm_val,
             .nodefault = true
         },
         [1] = {
@@ -139,7 +139,7 @@ TEST_CASE(test_cborattr_decode_object)
         [0] = {
             .attribute = "i",
             .type = CborAttrIntegerType,
-            .addr.integer = &i_val,
+            .addr.integer = (long long int *) &i_val,
             .nodefault = true
         },
         [1] = {
@@ -167,7 +167,7 @@ TEST_CASE(test_cborattr_decode_object)
         [1] = {
             .attribute = "a",
             .type = CborAttrIntegerType,
-            .addr.integer = &a_val,
+            .addr.integer = (long long int *) &a_val,
             .nodefault = true
         },
         [2] = {

--- a/cborattr/test/src/testcases/cborattr_decode_simple.c
+++ b/cborattr/test/src/testcases/cborattr_decode_simple.c
@@ -91,13 +91,13 @@ TEST_CASE(test_cborattr_decode_simple)
         [0] = {
             .attribute = "a",
             .type = CborAttrIntegerType,
-            .addr.uinteger = &a_val,
+            .addr.uinteger = (long long unsigned int *) &a_val,
             .nodefault = true
         },
         [1] = {
             .attribute = "b",
             .type = CborAttrIntegerType,
-            .addr.integer = &b_val,
+            .addr.integer = (long long int *) &b_val,
             .nodefault = true
         },
         [2] = {

--- a/cborattr/test/src/testcases/cborattr_decode_unnamed_array.c
+++ b/cborattr/test/src/testcases/cborattr_decode_unnamed_array.c
@@ -78,7 +78,7 @@ TEST_CASE(test_cborattr_decode_unnamed_array)
             .attribute = CBORATTR_ATTR_UNNAMED,
             .type = CborAttrArrayType,
             .addr.array.element_type = CborAttrIntegerType,
-            .addr.array.arr.integers.store = arr_data,
+            .addr.array.arr.integers.store = (long long int *) arr_data,
             .addr.array.count = &arr_cnt,
             .addr.array.maxlen = sizeof(arr_data) / sizeof(arr_data[0]),
             .nodefault = true


### PR DESCRIPTION
This allows running newt unit tests on 64-bit architecture. Without it, compilation errors were occurring (type mismatch).