### PR TITLE
log_mgmt: Zero-initialize log_offset struct

### DIFF
--- a/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
+++ b/cmd/log_mgmt/port/mynewt/src/mynewt_log_mgmt.c
@@ -228,7 +228,7 @@ log_mgmt_impl_foreach_entry(const char *log_name,
                             log_mgmt_foreach_entry_fn *cb, void *arg)
 {
     struct mynewt_log_mgmt_walk_arg walk_arg;
-    struct log_offset offset;
+    struct log_offset offset = {};
     struct log *log;
 
     walk_arg = (struct mynewt_log_mgmt_walk_arg) {


### PR DESCRIPTION
1063e8201 in mynewt-core added new field to log_offset struct so functions that define that struct on stack may have random results if struct is not initialized properly.