### PR TITLE
Mynwet fixes for accessing file system

### DIFF
--- a/cmd/fs_mgmt/port/mynewt/pkg.yml
+++ b/cmd/fs_mgmt/port/mynewt/pkg.yml
@@ -24,4 +24,4 @@ pkg.homepage: "http://mynewt.apache.org/"
 pkg.keywords:
 
 pkg.deps:
-    - '@apache-mynewt-mcumgr/cmd/fs'
+    - '@apache-mynewt-mcumgr/cmd/fs_mgmt'

--- a/cmd/fs_mgmt/port/mynewt/pkg.yml
+++ b/cmd/fs_mgmt/port/mynewt/pkg.yml
@@ -25,3 +25,5 @@ pkg.keywords:
 
 pkg.deps:
     - '@apache-mynewt-mcumgr/cmd/fs_mgmt'
+
+pkg.whole_archive: true

--- a/cmd/fs_mgmt/port/mynewt/src/mynewt_fs_mgmt.c
+++ b/cmd/fs_mgmt/port/mynewt/src/mynewt_fs_mgmt.c
@@ -25,6 +25,7 @@ int
 fs_mgmt_impl_filelen(const char *path, size_t *out_len)
 {
     struct fs_file *file;
+    uint32_t file_size;
     int rc;
 
     rc = fs_open(path, FS_ACCESS_READ, &file);
@@ -32,11 +33,13 @@ fs_mgmt_impl_filelen(const char *path, size_t *out_len)
         return MGMT_ERR_EUNKNOWN;
     }
 
-    rc = fs_filelen(file, &out_len);
+    rc = fs_filelen(file, &file_size);
     fs_close(file);
     if (rc != 0) {
         return MGMT_ERR_EUNKNOWN;
     }
+
+    *out_len = file_size;
 
     return 0;
 }
@@ -59,7 +62,7 @@ fs_mgmt_impl_read(const char *path, size_t offset, size_t len,
         goto done;
     }
 
-    rc = fs_read(file, len, file_data, &bytes_read);
+    rc = fs_read(file, len, out_data, &bytes_read);
     if (rc != 0) {
         goto done;
     }


### PR DESCRIPTION
There were incompatible types used
and typo in variable names preventing this
to ever build.

Dependency to cmd/fs_mgmt was also incorrect in
cmd/mynewt_fs_mgmt

Mynwet package now have"
```yml
whole_archive : true
```
to chose actual read and write implementations instead of stub functions.

It look like this functionality was never tried